### PR TITLE
refresh player content when play is clicked 

### DIFF
--- a/src/contexts/RadioPlayerContext.js
+++ b/src/contexts/RadioPlayerContext.js
@@ -23,6 +23,7 @@ export const RadioPlayerContextProvider = ({ children, audioRef }) => {
     } else {
       clickedPlay();
       setPlaying(true);
+      audioRef.current.load();
       audioRef.current.play();
     }
   };


### PR DESCRIPTION
Make sure the current stream is loaded after play is clicked to avoid content buffering over longer pause periods