### PR TITLE
Fix website crashing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,12 +10,8 @@ import { MixcloudWidgetContextProvider } from "./contexts/MixcloudWidgetContext"
 import { DeviceInfoContextProvider } from "./contexts/DeviceInfoContext";
 
 export const App = () => {
-  const {
-    aboutPageData,
-    supportPageData,
-    residentsData,
-    carouselData,
-  } = usePrismicData();
+  const { aboutPageData, supportPageData, residentsData, carouselData } =
+    usePrismicData();
   const currentShowData = useCurrentShowData();
   const scheduleData = useScheduleData();
   const audioRef = useRef(null);
@@ -23,7 +19,7 @@ export const App = () => {
   const path = window.location.pathname;
 
   const essentialDataFetchingFinished = () => {
-    const essentialForAllPaths = currentShowData && residentsData;
+    const essentialForAllPaths = residentsData;
 
     if (path === "/") {
       return Boolean(
@@ -52,7 +48,7 @@ export const App = () => {
         <RadioPlayerContextProvider audioRef={audioRef}>
           <MixcloudWidgetContextProvider>
             <DeviceInfoContextProvider>
-              <Audio refProp={audioRef} />
+              <Audio audioRef={audioRef} />
               <Main
                 aboutPageData={aboutPageData}
                 supportPageData={supportPageData}

--- a/src/App.js
+++ b/src/App.js
@@ -21,14 +21,6 @@ export const App = () => {
   const essentialDataFetchingFinished = () => {
     const essentialForAllPaths = residentsData;
 
-    if (path === "/") {
-      return Boolean(
-        essentialForAllPaths &&
-          carouselData.allCarouselItems &&
-          carouselData.additionalCarousels
-      );
-    }
-
     if (path.includes("/residents")) {
       return Boolean(essentialForAllPaths);
     }
@@ -40,6 +32,12 @@ export const App = () => {
     if (path === "/support") {
       return Boolean(essentialForAllPaths && supportPageData);
     }
+
+    return Boolean(
+      essentialForAllPaths &&
+        carouselData.allCarouselItems &&
+        carouselData.additionalCarousels
+    );
   };
 
   return (

--- a/src/components/audio/index.js
+++ b/src/components/audio/index.js
@@ -1,8 +1,9 @@
 import React from "react";
 
-const Audio = ({ refProp }) => (
-  <audio ref={refProp} id="audioPlayer" name="media">
+const Audio = ({ audioRef }) => (
+  <audio ref={audioRef} id="audioPlayer" name="media">
     <source src="https://ehfm.out.airtime.pro/ehfm_a" type="audio/mpeg" />
   </audio>
 );
+
 export default Audio;

--- a/src/components/current-show/CurrentShow.js
+++ b/src/components/current-show/CurrentShow.js
@@ -68,7 +68,7 @@ const CurrentShow = ({ currentShow, residentsData }) => {
   return (
     <Wrapper>
       <OnAirWrapper>
-        <OnAir isOnAir={Boolean(currentShow)} />
+        <OnAir isOnAir={!!currentShow} />
       </OnAirWrapper>
       <CurrentShowImageWrapper>{returnImage()}</CurrentShowImageWrapper>
       <InfoWrapper>

--- a/src/components/current-show/CurrentShow.js
+++ b/src/components/current-show/CurrentShow.js
@@ -68,7 +68,7 @@ const CurrentShow = ({ currentShow, residentsData }) => {
   return (
     <Wrapper>
       <OnAirWrapper>
-        <OnAir on={Boolean(currentShow)} />
+        <OnAir isOnAir={Boolean(currentShow)} />
       </OnAirWrapper>
       <CurrentShowImageWrapper>{returnImage()}</CurrentShowImageWrapper>
       <InfoWrapper>
@@ -78,7 +78,7 @@ const CurrentShow = ({ currentShow, residentsData }) => {
           </NameWrapper>
         ) : null}
         {currentShow && prismicShow && prismicShow.uid ? (
-          <Link to={`/residents/${(prismicShow && prismicShow.uid) || ""}`}>
+          <Link to={`/residents/${prismicShow.uid || ""}`}>
             <NameWrapper
               onMouseOver={() => {
                 setHovered(true);

--- a/src/components/current-show/CurrentShow.js
+++ b/src/components/current-show/CurrentShow.js
@@ -20,8 +20,7 @@ const CurrentShow = ({ currentShow, residentsData }) => {
   const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
-    if (currentShow && residentsData)
-      setPrismicShow(getShowInPrismic({ residentsData, currentShow }));
+    setPrismicShow(getShowInPrismic({ residentsData, currentShow }));
   }, [currentShow, residentsData]);
 
   const airTimeShowImgUrl = () => {

--- a/src/components/current-show/CurrentShow.js
+++ b/src/components/current-show/CurrentShow.js
@@ -20,7 +20,8 @@ const CurrentShow = ({ currentShow, residentsData }) => {
   const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
-    setPrismicShow(getShowInPrismic({ residentsData, currentShow }));
+    if (currentShow && residentsData)
+      setPrismicShow(getShowInPrismic({ residentsData, currentShow }));
   }, [currentShow, residentsData]);
 
   const airTimeShowImgUrl = () => {
@@ -54,60 +55,58 @@ const CurrentShow = ({ currentShow, residentsData }) => {
   };
 
   const returnShowDescription = () => {
-    let currentShowDescription = null;
     if (prismicShow && prismicShow.data && prismicShow.data.show_description) {
       return sanitiseString(prismicShow.data.show_description);
     }
-    if (currentShow !== null) {
-      currentShowDescription = currentShow.description;
-      if (currentShowDescription === "") {
-        currentShowDescription = "Edinburgh Community Radio.";
-        return currentShowDescription;
-      } else {
-        return sanitiseString(currentShowDescription);
-      }
+
+    if (currentShow && currentShow.description) {
+      return sanitiseString(currentShow.description);
     }
+
+    return "Edinburgh Community Radio.";
   };
 
   return (
     <Wrapper>
       <OnAirWrapper>
-        <OnAir />
+        <OnAir on={Boolean(currentShow)} />
       </OnAirWrapper>
-      {prismicShow && (
-        <>
-          <CurrentShowImageWrapper>{returnImage()}</CurrentShowImageWrapper>
-          <InfoWrapper>
-            {prismicShow === SHOW_NOT_FOUND ? (
-              <NameWrapper>
-                <ShowName>{parseShowName(currentShow)}</ShowName>
-              </NameWrapper>
-            ) : (
-              <Link to={`/residents/${prismicShow.uid}`}>
-                <NameWrapper
-                  onMouseOver={() => {
-                    setHovered(true);
-                  }}
-                  onMouseOut={() => {
-                    setHovered(false);
-                  }}
-                >
-                  <ShowName>{parseShowName(currentShow)}</ShowName>
-                  <HoveredLine
-                    hovered={hovered}
-                    width={"100%"}
-                    placeholderWidth={"3rem"}
-                    placeholder
-                  />
-                </NameWrapper>
-              </Link>
-            )}
-            <DescriptionWrapper>
-              <ShowDescription>{returnShowDescription()}</ShowDescription>
-            </DescriptionWrapper>
-          </InfoWrapper>
-        </>
-      )}
+      <CurrentShowImageWrapper>{returnImage()}</CurrentShowImageWrapper>
+      <InfoWrapper>
+        {currentShow && prismicShow === SHOW_NOT_FOUND ? (
+          <NameWrapper>
+            <ShowName>{parseShowName(currentShow)}</ShowName>
+          </NameWrapper>
+        ) : null}
+        {currentShow && prismicShow && prismicShow.uid ? (
+          <Link to={`/residents/${(prismicShow && prismicShow.uid) || ""}`}>
+            <NameWrapper
+              onMouseOver={() => {
+                setHovered(true);
+              }}
+              onMouseOut={() => {
+                setHovered(false);
+              }}
+            >
+              <ShowName>{parseShowName(currentShow)}</ShowName>
+              <HoveredLine
+                hovered={hovered}
+                width={"100%"}
+                placeholderWidth={"3rem"}
+                placeholder
+              />
+            </NameWrapper>
+          </Link>
+        ) : null}
+        {!currentShow ? (
+          <NameWrapper>
+            <ShowName>We are currently offline.</ShowName>
+          </NameWrapper>
+        ) : null}
+        <DescriptionWrapper>
+          <ShowDescription>{returnShowDescription()}</ShowDescription>
+        </DescriptionWrapper>
+      </InfoWrapper>
     </Wrapper>
   );
 };

--- a/src/components/nav-bar/MobileNavBar.js
+++ b/src/components/nav-bar/MobileNavBar.js
@@ -12,7 +12,7 @@ const MobileNavBar = (props) => {
         <MobileNavMenu />
       </Left>
       <Right>
-        <ShopButton mobile />
+        <ShopButton />
         <ChatangoButton mobile />
       </Right>
     </Inner>

--- a/src/components/nav-bar/logo/Logo.js
+++ b/src/components/nav-bar/logo/Logo.js
@@ -9,7 +9,7 @@ const LogoHead = ({ mobile, color }) => {
     <React.Fragment>
       <Wrapper>
         <Link to="/">
-          <StyledLogo color={color} mobile={mobile} />
+          <StyledLogo color={color} mobile={mobile ? "mobile" : "desktop"} />
         </Link>
       </Wrapper>
     </React.Fragment>
@@ -21,7 +21,7 @@ const Wrapper = styled.div`
 `;
 
 const StyledLogo = styled(Logo)`
-  height: ${(props) => (props.mobile ? "1.75rem" : "2.5rem")};
+  height: ${(props) => (props.mobile === "mobile" ? "1.75rem" : "2.5rem")};
   width: auto;
   path,
   polygon {

--- a/src/components/players/player/Player.js
+++ b/src/components/players/player/Player.js
@@ -12,17 +12,13 @@ import { sanitiseString } from "../../../helpers/PrismicHelper";
 
 const Player = ({ currentShow }) => {
   const [hovered, setHovered] = useState(false);
-  const {
-    playing,
-    handlePlayPauseClicked,
-    volume,
-    handleVolumeClicked,
-  } = useContext(RadioPlayerContext);
+  const { playing, handlePlayPauseClicked, volume, handleVolumeClicked } =
+    useContext(RadioPlayerContext);
 
   return (
     <Wrapper>
       <OnAirWrapper>
-        <OnAir />
+        <OnAir on={Boolean(currentShow)} />
       </OnAirWrapper>
       <Left
         onClick={handlePlayPauseClicked}
@@ -38,12 +34,15 @@ const Player = ({ currentShow }) => {
         <PlayPauseWrapper playing={playing} hovered={hovered}>
           <PlayPauseButton playing={playing} />
         </PlayPauseWrapper>
-
-        {currentShow ? (
+        {currentShow && currentShow.name ? (
           <CurrentShowText playing={playing} hovered={hovered}>
             {sanitiseString(currentShow.name)}
           </CurrentShowText>
-        ) : null}
+        ) : (
+          <CurrentShowText playing={playing} hovered={hovered}>
+            We are currently offline.
+          </CurrentShowText>
+        )}
         <PlayBorder />
       </Left>
       <Right>

--- a/src/components/players/player/Player.js
+++ b/src/components/players/player/Player.js
@@ -18,7 +18,7 @@ const Player = ({ currentShow }) => {
   return (
     <Wrapper>
       <OnAirWrapper>
-        <OnAir on={Boolean(currentShow)} />
+        <OnAir isOnAir={Boolean(currentShow)} />
       </OnAirWrapper>
       <Left
         onClick={handlePlayPauseClicked}

--- a/src/components/players/player/Player.js
+++ b/src/components/players/player/Player.js
@@ -18,7 +18,7 @@ const Player = ({ currentShow }) => {
   return (
     <Wrapper>
       <OnAirWrapper>
-        <OnAir isOnAir={Boolean(currentShow)} />
+        <OnAir isOnAir={!!currentShow} />
       </OnAirWrapper>
       <Left
         onClick={handlePlayPauseClicked}

--- a/src/components/players/player/on-air/OnAir.js
+++ b/src/components/players/player/on-air/OnAir.js
@@ -4,11 +4,11 @@ import Colors from "../../../../consts/Colors";
 import { Tiny } from "../../../text-elements/index";
 import Devices from "../../../../consts/Devices";
 
-const OnAir = () => {
+const OnAir = ({ on }) => {
   return (
     <OnAirWrapper>
-      <OnAirText>on air</OnAirText>
-      <Circle />
+      <OnAirText>{on ? "on air" : "off air"}</OnAirText>
+      {on ? <PulsingCircle /> : <RedCircle />}
     </OnAirWrapper>
   );
 };
@@ -38,7 +38,15 @@ const OnAirText = styled(Tiny)`
   }
 `;
 
-const Circle = styled.div`
+const RedCircle = styled.div`
+  background: ${Colors.offRed};
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 7px;
+`;
+
+const PulsingCircle = styled.div`
   background: ${Colors.highlightYellow()};
   width: 8px;
   height: 8px;

--- a/src/components/players/player/on-air/OnAir.js
+++ b/src/components/players/player/on-air/OnAir.js
@@ -4,11 +4,11 @@ import Colors from "../../../../consts/Colors";
 import { Tiny } from "../../../text-elements/index";
 import Devices from "../../../../consts/Devices";
 
-const OnAir = ({ on }) => {
+const OnAir = ({ isOnAir }) => {
   return (
     <OnAirWrapper>
-      <OnAirText>{on ? "on air" : "off air"}</OnAirText>
-      {on ? <PulsingCircle /> : <RedCircle />}
+      <OnAirText>{isOnAir ? "on air" : "off air"}</OnAirText>
+      {isOnAir ? <PulsingCircle /> : <RedCircle />}
     </OnAirWrapper>
   );
 };

--- a/src/components/players/side-player/SidePlayer.js
+++ b/src/components/players/side-player/SidePlayer.js
@@ -16,12 +16,10 @@ const SidePlayer = ({ currentShow, residentsData, scheduleData }) => {
       <SidePlayerOuter>
         <Logo />
         <CurrentShowAndPlayerWrapper>
-          {currentShow ? (
-            <CurrentShow
-              currentShow={currentShow}
-              residentsData={residentsData}
-            />
-          ) : null}
+          <CurrentShow
+            currentShow={currentShow}
+            residentsData={residentsData}
+          />
           <Player currentShow={currentShow} />
         </CurrentShowAndPlayerWrapper>
         <ScheduleWrapper>

--- a/src/components/schedule/Schedule.js
+++ b/src/components/schedule/Schedule.js
@@ -8,26 +8,29 @@ import { getShowInPrismic } from "../../helpers/PrismicHelper";
 const Schedule = ({ scheduleData, residentsData }) => {
   return (
     <Wrapper>
-      <ComingUpText>Coming up...</ComingUpText>
-      <ScheduleItemsWrapper>
-        {scheduleData &&
-          scheduleData.map((scheduleItemData, i) => {
-            const foundShow = getShowInPrismic({
-              residentsData,
-              currentShow: scheduleItemData,
-            });
+      {scheduleData && scheduleData.length ? (
+        <>
+          <ComingUpText>Coming up...</ComingUpText>
+          <ScheduleItemsWrapper>
+            {scheduleData.map((scheduleItemData, i) => {
+              const foundShow = getShowInPrismic({
+                residentsData,
+                currentShow: scheduleItemData,
+              });
 
-            return (
-              <ScheduleItem
-                key={i}
-                showName={scheduleItemData.name}
-                starts={scheduleItemData.starts}
-                foundShow={foundShow}
-              />
-            );
-          })}
-      </ScheduleItemsWrapper>
-      <GradientWrapper />
+              return (
+                <ScheduleItem
+                  key={i}
+                  showName={scheduleItemData.name}
+                  starts={scheduleItemData.starts}
+                  foundShow={foundShow}
+                />
+              );
+            })}
+          </ScheduleItemsWrapper>
+          <GradientWrapper />
+        </>
+      ) : null}
     </Wrapper>
   );
 };

--- a/src/components/schedule/Schedule.js
+++ b/src/components/schedule/Schedule.js
@@ -8,7 +8,7 @@ import { getShowInPrismic } from "../../helpers/PrismicHelper";
 const Schedule = ({ scheduleData, residentsData }) => {
   return (
     <Wrapper>
-      {scheduleData && scheduleData.length ? (
+      {scheduleData && scheduleData.length > 0 ? (
         <>
           <ComingUpText>Coming up...</ComingUpText>
           <ScheduleItemsWrapper>

--- a/src/consts/Colors.js
+++ b/src/consts/Colors.js
@@ -16,4 +16,5 @@ export default {
   spanBgSolid: `rgba(47, 62, 70, 0.97)`,
   softGrey: `rgb(223, 223, 223)`,
   softerGrey: `rgb(239, 239, 239)`,
+  offRed: `#ff0000b5`,
 };

--- a/src/containers/home/Home.js
+++ b/src/containers/home/Home.js
@@ -10,16 +10,18 @@ import AdditionalCarouselHeading from "../../components/additional-carousel-head
 import { MixcloudWidgetContext } from "../../contexts/MixcloudWidgetContext";
 
 const filterIncompleteItems = (items) =>
-  items.filter(
-    ({ data }) =>
-      data.headline &&
-      data.link &&
-      data.type &&
-      data.category &&
-      data.headline &&
-      data.image &&
-      data.image.url
-  );
+  items
+    ? items.filter(
+        ({ data }) =>
+          data.headline &&
+          data.link &&
+          data.type &&
+          data.category &&
+          data.headline &&
+          data.image &&
+          data.image.url
+      )
+    : [];
 
 const HomeContainer = ({ carouselData }) => {
   const [cookies] = useCookies(["ehfm"]);
@@ -77,12 +79,15 @@ const HomeContainer = ({ carouselData }) => {
     };
 
     const getCarousels = () =>
-      additionalCarousels.map((carouselData) => {
-        const carouselItems = getCarouselItems(carouselData);
-        carouselData.data.carousel_items = filterIncompleteItems(carouselItems);
-        carouselData.data.id = carouselData.id;
-        return carouselData.data;
-      });
+      additionalCarousels
+        ? additionalCarousels.map((carouselData) => {
+            const carouselItems = getCarouselItems(carouselData);
+            carouselData.data.carousel_items =
+              filterIncompleteItems(carouselItems);
+            carouselData.data.id = carouselData.id;
+            return carouselData.data;
+          })
+        : [];
 
     const carouselsWithParsedData = getCarousels();
     const carouselsSortedByPosition = sortCarouselsByPosition(

--- a/src/containers/home/Home.js
+++ b/src/containers/home/Home.js
@@ -111,7 +111,6 @@ const HomeContainer = ({ carouselData }) => {
               const sortedData = reverseChronologicalSort(
                 carousel.carousel_items
               );
-              console.log("sortedData", sortedData);
               return (
                 <AdditionalCarouselWrapper key={carousel.id}>
                   <AdditionalCarouselHeading

--- a/src/containers/home/Home.js
+++ b/src/containers/home/Home.js
@@ -9,16 +9,27 @@ import { WidgetMarginStyles, PagePaddingStyles } from "../../consts/Styles";
 import AdditionalCarouselHeading from "../../components/additional-carousel-heading/AdditionalCarouselHeading";
 import { MixcloudWidgetContext } from "../../contexts/MixcloudWidgetContext";
 
+const filterIncompleteItems = (items) =>
+  items.filter(
+    ({ data }) =>
+      data.headline &&
+      data.link &&
+      data.type &&
+      data.category &&
+      data.headline &&
+      data.image &&
+      data.image.url
+  );
+
 const HomeContainer = ({ carouselData }) => {
   const [cookies] = useCookies(["ehfm"]);
   const { mixcloudWidgetHtml, handleMixcloudClick } = useContext(
     MixcloudWidgetContext
   );
   const [highlightedCarouselItems, setHighlightedCarouselItems] = useState([]);
-  const [
-    additionalCarouselsWithItems,
-    setAdditionalCarouselsWithItems,
-  ] = useState([]);
+  const [additionalCarouselsWithItems, setAdditionalCarouselsWithItems] =
+    useState([]);
+
   const PrimaryCarousel = Carousel;
   const { allCarouselItems, additionalCarousels } = carouselData;
 
@@ -32,13 +43,9 @@ const HomeContainer = ({ carouselData }) => {
 
   // Get 'highlighted' carousel items
   useEffect(() => {
-    const filterHighlightedCarouselItems = () => {
-      return allCarouselItems.filter((featuredItem) => {
-        return featuredItem.data.highlighted;
-      });
-    };
-
-    const filteredHighlightedCarouselItems = filterHighlightedCarouselItems();
+    const filteredHighlightedCarouselItems = filterIncompleteItems(
+      allCarouselItems
+    ).filter((featuredItem) => featuredItem.data.highlighted);
     const sortedByMostRecent = reverseChronologicalSort(
       filteredHighlightedCarouselItems
     );
@@ -72,7 +79,7 @@ const HomeContainer = ({ carouselData }) => {
     const getCarousels = () =>
       additionalCarousels.map((carouselData) => {
         const carouselItems = getCarouselItems(carouselData);
-        carouselData.data.carousel_items = carouselItems;
+        carouselData.data.carousel_items = filterIncompleteItems(carouselItems);
         carouselData.data.id = carouselData.id;
         return carouselData.data;
       });
@@ -104,6 +111,7 @@ const HomeContainer = ({ carouselData }) => {
               const sortedData = reverseChronologicalSort(
                 carousel.carousel_items
               );
+              console.log("sortedData", sortedData);
               return (
                 <AdditionalCarouselWrapper key={carousel.id}>
                   <AdditionalCarouselHeading

--- a/src/containers/main/Main.js
+++ b/src/containers/main/Main.js
@@ -1,5 +1,11 @@
 import React, { useEffect } from "react";
-import { Route, Switch, useLocation, useHistory } from "react-router-dom";
+import {
+  Route,
+  Switch,
+  useLocation,
+  useHistory,
+  Redirect,
+} from "react-router-dom";
 import styled from "styled-components/macro";
 import Header from "../header/Header";
 import SidePlayer from "../../components/players/side-player/SidePlayer";
@@ -59,8 +65,11 @@ const Main = ({
             <Route exact path="/support">
               <Support pageData={supportPageData} />
             </Route>
-            <Route path="/*">
+            <Route exact path="/">
               <Home carouselData={carouselData} />
+            </Route>
+            <Route path="/*">
+              <Redirect to="/" />
             </Route>
           </Switch>
         </MainInner>

--- a/src/containers/main/Main.js
+++ b/src/containers/main/Main.js
@@ -59,7 +59,7 @@ const Main = ({
             <Route exact path="/support">
               <Support pageData={supportPageData} />
             </Route>
-            <Route exact path="/">
+            <Route path="/*">
               <Home carouselData={carouselData} />
             </Route>
           </Switch>

--- a/src/helpers/PrismicHelper.js
+++ b/src/helpers/PrismicHelper.js
@@ -10,6 +10,7 @@ export const sanitiseString = (string) => {
 };
 
 export const getShowInPrismic = ({ residentsData, currentShow }) => {
+  if (!currentShow || !residentsData) return SHOW_NOT_FOUND;
   let toLowerCase;
   const currentShowName = parseShowName(currentShow);
   if (currentShowName) {

--- a/src/hooks/useCurrentShowData.js
+++ b/src/hooks/useCurrentShowData.js
@@ -8,7 +8,13 @@ export const useCurrentShowData = () => {
   const currentShowApiCall = useCallback(() => {
     fetch("https://ehfm.airtime.pro/api/live-info")
       .then((response) => response.json())
-      .then((data) => setCurrentShowData(data.currentShow[0]));
+      .then((data) => {
+        if (data && data.currentShow && data.currentShow[0])
+          setCurrentShowData(data.currentShow[0]);
+      })
+      .catch((err) => {
+        setCurrentShowData(null);
+      });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes 2 events causing website to crash.

1. If incomplete item is saved Prismic. Fixed by [filtering incomplete items](https://github.com/RichardPK/eh-fm/pull/44/commits/6dd43b3189298594475ece4cc64f0b53139253f3).
2. If there is no current show. Fixed by removing [`currentShow` from `essentialForAllPaths`](https://github.com/RichardPK/eh-fm/pull/44/files#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67R22) condition and adding fallback Components.

**Fallback components**

**Mobile with show**

<img width="513" alt="Screenshot 2022-09-15 at 22 34 14" src="https://user-images.githubusercontent.com/22624697/190515099-db4387dd-c14a-4d67-8433-b96b039aee9f.png">

**Mobile no show**

<img width="485" alt="Screenshot 2022-09-15 at 22 33 57" src="https://user-images.githubusercontent.com/22624697/190515106-72dfe250-c911-47b4-812e-3484082ebc9d.png">

**Desktop with show**

<img width="1440" alt="Screenshot 2022-09-15 at 22 31 26" src="https://user-images.githubusercontent.com/22624697/190515120-c13c835f-0a1d-4a3e-b90c-dd5e3558d187.png">

**Desktop no show**

<img width="1440" alt="Screenshot 2022-09-15 at 22 33 14" src="https://user-images.githubusercontent.com/22624697/190515113-b4f679c7-5a42-4431-a398-482e6debfd28.png">

